### PR TITLE
Removes unused code

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -34,9 +34,7 @@ module.exports = function(opts) {
 
   return function(build, done){
     setImmediate(done);
-    var list = build.components;
     var partials = [];
-    var componentName = list[0].name;
 
     build.map('templates', function(file, conf){
       var ext = path.extname(file.filename);
@@ -64,20 +62,19 @@ module.exports = function(opts) {
       return file;
     });
 
-    build.handlebars = runtime(list[0].name, partials);
+    build.handlebars = runtime(partials);
   }
 }
 
 /**
  * Handlebars runtime with partials.
  *
- * @param {String} name
  * @param {String[]} partials
  * @return {String}
  * @api private
  */
 
-function runtime(name, partials){
+function runtime(partials){
   var runtimeFilepath = path.join(__dirname, '../node_modules/handlebars/dist/handlebars.runtime.js');
   if (!exists(runtimeFilepath)) runtimeFilepath = path.join(__dirname, '/handlebars.runtime.js');
 


### PR DESCRIPTION
The `build.components` array is always undefined in my test cases. Removed it as it doesn't seem to be used. The first argument to `runtime` doesn't seem to be used either. This simplifies the execution of a local utility.
